### PR TITLE
Adds `EventDispatcher`

### DIFF
--- a/src/THREE/EventDispatcher.hs
+++ b/src/THREE/EventDispatcher.hs
@@ -1,26 +1,36 @@
 -----------------------------------------------------------------------------
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 module THREE.EventDispatcher
   ( -- * Types
     EventDispatcher (..)
-    -- * Methods
-  , THREE.EventDispatcher.new
-    -- * Properties
   ) where
 -----------------------------------------------------------------------------
 import           Language.Javascript.JSaddle
 -----------------------------------------------------------------------------
-import qualified THREE.Internal as THREE
+import           THREE.Internal as THREE
 -----------------------------------------------------------------------------
--- | https://threejs.org/docs/#api/en/scenes/EventDispatcher
-newtype EventDispatcher
-  = EventDispatcher
-  { unEventDispatcherCamera :: JSVal
-  } deriving (MakeObject)
+-- | https://threejs.org/docs/#api/en/core/EventDispatcher
+class (MakeObject object, ToJSVal object) => EventDispatcher object where
+  addEventListener :: Method object "addEventListener" (JSString, Function) JSUndefined
+  -- ^ Adds a listener to an event type.
+  addEventListener = method
+
+  hasEventListener :: Method object "hasEventListener" (JSString, Function) JSUndefined
+  -- ^ Checks if listener is added to an event type.
+  hasEventListener = method
+
+  removeEventListener :: Method object "removeEventListener" (JSString, Function) JSUndefined
+  -- ^ Removes a listener from an event type.
+  removeEventListener = method
+
+  dispatchEvent :: Method object "dispatchEvent" Object JSUndefined
+  -- ^ Dispatches an Event
+  dispatchEvent = method
 -----------------------------------------------------------------------------
--- | https://threejs.org/docs/#api/en/cameras/EventDispatcher
-new :: THREE.Three EventDispatcher
-new = THREE.new EventDispatcher "EventDispatcher" ([] :: [JSString])
+instance EventDispatcher JSVal
 -----------------------------------------------------------------------------
+
+

--- a/src/THREE/Internal.hs
+++ b/src/THREE/Internal.hs
@@ -36,7 +36,7 @@ module THREE.Internal
   , optional
   , new
   -- * Classes
-  , Thruple (..)
+  , Triplet (..)
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad
@@ -124,10 +124,10 @@ readonly
   => Proxy name -> object -> Three return
 readonly name object = fromJSValUnchecked =<< (object ! symbolVal name)
 -----------------------------------------------------------------------------
-new 
+new
   :: MakeArgs args
-  => (JSVal -> con) 
-  -> JSString 
+  => (JSVal -> con)
+  -> JSString
   -> args
   -> Three con
 new f name args = do
@@ -197,13 +197,13 @@ class MakeObject object => W object where
 -----------------------------------------------------------------------------
 instance W JSVal
 -----------------------------------------------------------------------------
--- | Class for dealing with overloaded thruple like arguments
+-- | Class for dealing with overloaded triplet like arguments
 -- (e.g. 'Vector3', '(Int,Int,Int)'), see use in 'Object3D', 'lookAt'
-class ToJSVal args => Thruple args where
-  thruple :: args -> JSM JSVal 
+class ToJSVal args => Triplet args where
+  triplet :: args -> JSM JSVal
 -----------------------------------------------------------------------------
-instance ToJSVal (x,y,z) => Thruple (x,y,z) where
-  thruple = toJSVal
+instance ToJSVal (x,y,z) => Triplet (x,y,z) where
+  triplet = toJSVal
 -----------------------------------------------------------------------------
 -- Some orphans, please put these back into `jsaddle`
 -----------------------------------------------------------------------------

--- a/src/THREE/Internal.hs
+++ b/src/THREE/Internal.hs
@@ -1,11 +1,15 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GADTs                      #-}
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 -----------------------------------------------------------------------------
 module THREE.Internal
   ( -- * Types
@@ -31,6 +35,8 @@ module THREE.Internal
   , readonly
   , optional
   , new
+  -- * Classes
+  , Thruple (..)
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad
@@ -190,4 +196,42 @@ class MakeObject object => W object where
   w = property
 -----------------------------------------------------------------------------
 instance W JSVal
+-----------------------------------------------------------------------------
+-- | Class for dealing with overloaded thruple like arguments
+-- (e.g. 'Vector3', '(Int,Int,Int)'), see use in 'Object3D', 'lookAt'
+class ToJSVal args => Thruple args where
+  thruple :: args -> JSM JSVal 
+-----------------------------------------------------------------------------
+instance ToJSVal (x,y,z) => Thruple (x,y,z) where
+  thruple = toJSVal
+-----------------------------------------------------------------------------
+-- Some orphans, please put these back into `jsaddle`
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance FromJSVal Function where
+  fromJSVal = pure . pure . Function . Object
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance FromJSVal Object where
+  fromJSVal = pure . pure . Object
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance MakeArgs Int where
+  makeArgs k = (:[]) <$> toJSVal k
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance MakeArgs Object where
+  makeArgs (Object k) = pure [k]
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance MakeArgs JSString where
+  makeArgs (JSString k) = makeArgs k
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance MakeArgs Function where
+  makeArgs (Function (Object k)) = pure [k]
+-----------------------------------------------------------------------------
+-- | This belongs in 'jsaddle'
+instance ToJSVal (SomeJSArray Immutable) where
+  toJSVal (SomeJSArray k) = pure k
 -----------------------------------------------------------------------------

--- a/src/THREE/Mesh.hs
+++ b/src/THREE/Mesh.hs
@@ -21,15 +21,14 @@ import           THREE.BufferGeometry (BufferGeometryClass)
 import qualified THREE.Internal as THREE
 import           THREE.Material as THREE
 import           THREE.Object3D as THREE
+import           THREE.EventDispatcher as THREE
 -----------------------------------------------------------------------------
 -- | https://threejs.org/docs/#api/en/objects/Mesh
 newtype Mesh
   = Mesh
   { unMesh :: JSVal
   } deriving (MakeArgs, MakeObject, ToJSVal) 
-    deriving Object3D via JSVal
------------------------------------------------------------------------------
--- Constructors
+    deriving (Object3D, EventDispatcher)
 -----------------------------------------------------------------------------
 new
   :: (BufferGeometryClass geometry, Material material)
@@ -37,14 +36,4 @@ new
   -> material
   -> THREE.Three Mesh
 new geometry material = THREE.new Mesh "Mesh" (geometry, material)
------------------------------------------------------------------------------
--- Read-only properties
------------------------------------------------------------------------------
--- Properties
------------------------------------------------------------------------------
--- Optional properties
------------------------------------------------------------------------------
--- Methods
------------------------------------------------------------------------------
--- Helper functions
 -----------------------------------------------------------------------------

--- a/src/THREE/Object3D.hs
+++ b/src/THREE/Object3D.hs
@@ -127,7 +127,7 @@ class EventDispatcher object => Object3D object where
   getWorldDirection = method
   localToWorld :: Method object "localToWorld" Vector3 Vector3
   localToWorld = method
-  lookAt :: (MakeArgs arg, Thruple arg) => Method object "lookAt" arg ()
+  lookAt :: (MakeArgs arg, Triplet arg) => Method object "lookAt" arg ()
   lookAt = method
   raycast :: Method object "raycast" (Raycaster, JSArray) JSUndefined
   raycast = method

--- a/src/THREE/Object3D.hs
+++ b/src/THREE/Object3D.hs
@@ -3,33 +3,28 @@
 {-# LANGUAGE TypeApplications        #-}
 {-# LANGUAGE OverloadedStrings       #-}
 {-# LANGUAGE ConstrainedClassMethods #-}
-{-# OPTIONS_GHC -fno-warn-orphans    #-}
 -----------------------------------------------------------------------------
 module THREE.Object3D
-  ( -- * Types
+  ( -- * Class
     Object3D (..)
-    -- * Constructors
-    -- * Read-only Properties
-    -- * Properties
-    -- * Optional properties
-    -- * Methods
   ) where
 -----------------------------------------------------------------------------
 import           Language.Javascript.JSaddle
 -----------------------------------------------------------------------------
-import           THREE.Euler         as THREE
-import           THREE.Internal      as THREE
-import           THREE.Vector3       as THREE
-import           THREE.Matrix3       as THREE
-import           THREE.Quaternion    as THREE
-import           THREE.Matrix4       as THREE
-import           THREE.Material      as THREE
-import           THREE.AnimationClip as THREE
-import           THREE.Layers        as THREE
-import           THREE.Raycaster     as THREE
+import           THREE.Euler           as THREE
+import           THREE.Internal        as THREE
+import           THREE.Vector3         as THREE
+import           THREE.Matrix3         as THREE
+import           THREE.Quaternion      as THREE
+import           THREE.Matrix4         as THREE
+import           THREE.Material        as THREE
+import           THREE.Layers          as THREE
+import           THREE.Raycaster       as THREE
+import           THREE.AnimationClip   as THREE
+import           THREE.EventDispatcher as THREE
 -----------------------------------------------------------------------------
 -- | https://threejs.org/docs/#api/en/core/Object3D
-class (MakeObject object, ToJSVal object) => Object3D object where
+class EventDispatcher object => Object3D object where
   animations :: Property object "animations" AnimationClip
   animations = property
   castShadow :: Property object "castShadow" Bool
@@ -60,7 +55,7 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   matrixWorldNeedsUpdate = property
   modelViewMatrix :: Property object "modelViewMatrix" Matrix4
   modelViewMatrix = property
-  name :: Property object "name" String
+  name :: Property object "name" JSString
   name = property
   normalMatrix :: Property object "normalMatrix" Matrix3
   normalMatrix = property
@@ -90,7 +85,7 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   up = property
   userData :: Property object "userData" Object
   userData = property
-  uuid :: Property object "uuid" String
+  uuid :: Property object "uuid" JSString
   uuid = property
   visible :: Property object "visible" Bool
   visible = property
@@ -102,7 +97,7 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   defaultMatrixWorldAutoUpdate = property
   add :: (MakeArgs arg, FromJSVal return, Object3D return, Object3D arg) => Method object "add" arg return
   add = method
-  applyMatrix4 :: (FromJSVal return, Object3D return) => Method object "applyMatrix4" Matrix4 return
+  applyMatrix4 :: Method object "applyMatrix4" Matrix4 JSUndefined
   applyMatrix4 = method
   applyQuaternion :: (FromJSVal return, Object3D return) => Method object "applyQuaternion" Quaternion return
   applyQuaternion = method
@@ -116,11 +111,11 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   copy = method
   getObjectById :: (FromJSVal return, Object3D return) => Method object "getObjectById" Int return
   getObjectById = method
-  getObjectByName :: (FromJSVal return, Object3D return) => Method object "getObjectByName" String return
+  getObjectByName :: (FromJSVal return, Object3D return) => Method object "getObjectByName" JSString return
   getObjectByName = method
   getObjectByProperty :: (Object3D return, FromJSVal return) => Method object "getObjectByProperty" (JSString, Object) return
   getObjectByProperty = method
-  getObjectsByProperty :: (FromJSVal return, Object3D return) => Method object "getObjectsByProperty" (String, Object, Object) return
+  getObjectsByProperty :: (FromJSVal return, Object3D return) => Method object "getObjectsByProperty" (JSString, Object, Object) return
   getObjectsByProperty = method
   getWorldPosition :: Method object "getWorldPosition" Vector3 Vector3
   getWorldPosition = method
@@ -132,10 +127,9 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   getWorldDirection = method
   localToWorld :: Method object "localToWorld" Vector3 Vector3
   localToWorld = method
-  -- .lookAt ( vector : Vector3 ) : undefined
-  lookAt :: Method object "lookAt" (Double, Double, Double) ()
+  lookAt :: (MakeArgs arg, Thruple arg) => Method object "lookAt" arg ()
   lookAt = method
-  raycast :: Method object "raycast" (Raycaster, Array) ()
+  raycast :: Method object "raycast" (Raycaster, JSArray) JSUndefined
   raycast = method
   remove :: (Object3D return, FromJSVal return, MakeArgs arg, Object3D arg) => Method object "remove" arg return
   remove = method
@@ -151,13 +145,13 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   rotateY = method
   rotateZ :: (FromJSVal return, Object3D return) => Method object "rotateZ" Double return
   rotateZ = method
-  setRotationFromAxisAngle :: Method object "setRotationFromAxisAngle" (Vector3, Double) ()
+  setRotationFromAxisAngle :: Method object "setRotationFromAxisAngle" (Vector3, Double) JSUndefined
   setRotationFromAxisAngle = method
-  setRotationFromEuler :: Method object "setRotationFromEuler" Euler ()
+  setRotationFromEuler :: Method object "setRotationFromEuler" Euler JSUndefined
   setRotationFromEuler = method
-  setRotationFromMatrix :: Method object "setRotationFromMatrix" Matrix4 ()
+  setRotationFromMatrix :: Method object "setRotationFromMatrix" Matrix4 JSUndefined
   setRotationFromMatrix = method
-  setRotationFromQuaternion :: Method object "setRotationFromQuaternion" Quaternion ()
+  setRotationFromQuaternion :: Method object "setRotationFromQuaternion" Quaternion JSUndefined
   setRotationFromQuaternion = method
   toJSON :: Method object "toJSON" Object Object
   toJSON = method
@@ -169,42 +163,20 @@ class (MakeObject object, ToJSVal object) => Object3D object where
   translateY = method
   translateZ :: (FromJSVal return, Object3D return) => Method object "translateZ" Double return
   translateZ = method
-  traverse :: Method object "traverse" Function ()
+  traverse :: Method object "traverse" Function JSUndefined
   traverse = method
-  traverseVisible :: Method object "traverseVisible" Function ()
+  traverseVisible :: Method object "traverseVisible" Function JSUndefined
   traverseVisible = method
-  traverseAncestors :: Method object "traverseAncestors" Function ()
+  traverseAncestors :: Method object "traverseAncestors" Function JSUndefined
   traverseAncestors = method
-  updateMatrix :: Method object "updateMatrix" () ()
+  updateMatrix :: Method object "updateMatrix" () JSUndefined
   updateMatrix = method
-  updateMatrixWorld :: Method object "updateMatrixWorld" Bool ()
+  updateMatrixWorld :: Method object "updateMatrixWorld" Bool JSUndefined
   updateMatrixWorld = method
-  updateWorldMatrix :: Method object "updateWorldMatrix" (Bool, Bool) ()
+  updateWorldMatrix :: Method object "updateWorldMatrix" (Bool, Bool) JSUndefined
   updateWorldMatrix = method
   worldToLocal :: Method object "worldToLocal" Vector3 Vector3
   worldToLocal = method
------------------------------------------------------------------------------
-type Array = Object
------------------------------------------------------------------------------
--- | This belongs in 'jsaddle'
-instance FromJSVal Function where
-  fromJSVal = pure . pure . Function . Object
------------------------------------------------------------------------------
--- | This belongs in 'jsaddle'
-instance FromJSVal Object where
-  fromJSVal = pure . pure . Object
------------------------------------------------------------------------------
--- | This belongs in 'jsaddle'
-instance MakeArgs Int where
-  makeArgs k = (:[]) <$> toJSVal k
------------------------------------------------------------------------------
--- | This belongs in 'jsaddle'
-instance MakeArgs Object where
-  makeArgs (Object k) = pure [k]
------------------------------------------------------------------------------
--- | This belongs in 'jsaddle'
-instance MakeArgs Function where
-  makeArgs (Function (Object k)) = pure [k]
 -----------------------------------------------------------------------------
 instance Object3D JSVal
 -----------------------------------------------------------------------------

--- a/src/THREE/PerspectiveCamera.hs
+++ b/src/THREE/PerspectiveCamera.hs
@@ -17,19 +17,17 @@ module THREE.PerspectiveCamera
 -----------------------------------------------------------------------------
 import           Language.Javascript.JSaddle
 -----------------------------------------------------------------------------
-import           THREE.Camera as THREE
-import           THREE.Internal as THREE
-import           THREE.Object3D as THREE
+import           THREE.Camera          as THREE
+import           THREE.Internal        as THREE
+import           THREE.Object3D        as THREE
+import           THREE.EventDispatcher as THREE
 -----------------------------------------------------------------------------
 -- | https://threejs.org/docs/#api/en/cameras/PerspectiveCamera
 newtype PerspectiveCamera
   = PerspectiveCamera
   { unPerspectiveCamera :: JSVal
-  } deriving (MakeArgs, MakeObject, ToJSVal) 
-    deriving newtype Camera
-    deriving Object3D via JSVal
------------------------------------------------------------------------------
--- Constructors
+  } deriving (MakeArgs, MakeObject, ToJSVal)
+    deriving (Object3D, EventDispatcher, Camera)
 -----------------------------------------------------------------------------
 new
   :: Double
@@ -41,17 +39,7 @@ new
   -> Double
   -- ^ Far
   -> THREE.Three PerspectiveCamera
-new fov aspect near far = 
+new fov aspect near far =
   THREE.new PerspectiveCamera "PerspectiveCamera"
     (fov, aspect, near, far)
------------------------------------------------------------------------------
--- Read-only properties
------------------------------------------------------------------------------
--- Properties
------------------------------------------------------------------------------
--- Optional properties
------------------------------------------------------------------------------
--- Methods
------------------------------------------------------------------------------
--- Helper functions
 -----------------------------------------------------------------------------

--- a/src/THREE/PointLight.hs
+++ b/src/THREE/PointLight.hs
@@ -20,27 +20,15 @@ import           Language.Javascript.JSaddle
 import           THREE.Internal as THREE
 import           THREE.Light as THREE
 import           THREE.Object3D as THREE
+import           THREE.EventDispatcher as THREE
 -----------------------------------------------------------------------------
 -- | https://threejs.org/docs/#api/en/lights/PointLight
 newtype PointLight
   = PointLight
   { unPointLight :: JSVal
-  } deriving (MakeArgs, MakeObject, ToJSVal) 
-    deriving newtype Light
-    deriving Object3D via JSVal
------------------------------------------------------------------------------
--- Constructors
+  } deriving (MakeArgs, MakeObject, ToJSVal)
+    deriving (Light, Object3D, EventDispatcher)
 -----------------------------------------------------------------------------
 new :: THREE.Three PointLight
 new = THREE.new PointLight "PointLight" ()
------------------------------------------------------------------------------
--- Read-only properties
------------------------------------------------------------------------------
--- Properties
------------------------------------------------------------------------------
--- Optional properties
------------------------------------------------------------------------------
--- Methods
------------------------------------------------------------------------------
--- Helper functions
 -----------------------------------------------------------------------------

--- a/src/THREE/Scene.hs
+++ b/src/THREE/Scene.hs
@@ -19,31 +19,19 @@ module THREE.Scene
 -----------------------------------------------------------------------------
 import           Language.Javascript.JSaddle
 -----------------------------------------------------------------------------
-import           THREE.Internal as THREE
-import           THREE.Object3D as THREE
+import           THREE.Internal        as THREE
+import           THREE.Object3D        as THREE
+import           THREE.EventDispatcher as THREE
 -----------------------------------------------------------------------------
 -- | https://threejs.org/docs/#api/en/scenes/Scene
 newtype Scene
   = Scene
   { unScene :: JSVal
-  } deriving (MakeArgs, MakeObject, ToJSVal) 
-    deriving Object3D via JSVal
------------------------------------------------------------------------------
--- Constructors
+  } deriving (Object3D, EventDispatcher, MakeArgs, MakeObject, ToJSVal) 
 -----------------------------------------------------------------------------
 new :: THREE.Three Scene
 new = THREE.new Scene "Scene" ()
 -----------------------------------------------------------------------------
--- Read-only properties
------------------------------------------------------------------------------
 isScene :: Property Scene "isScene" Bool
 isScene = property
------------------------------------------------------------------------------
--- Properties
------------------------------------------------------------------------------
--- Optional properties
------------------------------------------------------------------------------
--- Methods
------------------------------------------------------------------------------
---  functionselpers
 -----------------------------------------------------------------------------

--- a/src/THREE/Scene.hs
+++ b/src/THREE/Scene.hs
@@ -27,7 +27,8 @@ import           THREE.EventDispatcher as THREE
 newtype Scene
   = Scene
   { unScene :: JSVal
-  } deriving (Object3D, EventDispatcher, MakeArgs, MakeObject, ToJSVal) 
+  } deriving (MakeArgs, MakeObject, ToJSVal)
+    deriving (Object3D, EventDispatcher)
 -----------------------------------------------------------------------------
 new :: THREE.Three Scene
 new = THREE.new Scene "Scene" ()

--- a/src/THREE/Vector3.hs
+++ b/src/THREE/Vector3.hs
@@ -29,26 +29,14 @@ newtype Vector3
   } deriving (MakeObject, ToJSVal, MakeArgs, X, Y, Z)
 -----------------------------------------------------------------------------
 instance FromJSVal Vector3 where
-  fromJSVal = pure .Just . Vector3
------------------------------------------------------------------------------
--- constructors
+  fromJSVal = pure . Just . Vector3
 -----------------------------------------------------------------------------
 new :: Double -> Double -> Double -> THREE.Three Vector3
 new x_ y_ z_ = THREE.new Vector3 "Vector3" (x_, y_, z_)
 -----------------------------------------------------------------------------
--- read-only properties
------------------------------------------------------------------------------
--- properties
------------------------------------------------------------------------------
--- optional properties
------------------------------------------------------------------------------
--- methods
------------------------------------------------------------------------------
 setXYZ :: Double -> Double -> Double -> Vector3 -> THREE.Three ()
 setXYZ x_ y_ z_ (Vector3 v) =
   void $ v # ("set" :: JSString) $ (x_, y_, z_)
------------------------------------------------------------------------------
--- helper functions
 -----------------------------------------------------------------------------
 vector3ToXYZ :: Vector3 -> JSM (Double, Double, Double)
 vector3ToXYZ (Vector3 v) = do
@@ -56,5 +44,8 @@ vector3ToXYZ (Vector3 v) = do
   y_ <- fromJSValUnchecked =<< v ! ("y" :: JSString)
   z_ <- fromJSValUnchecked =<< v ! ("z" :: JSString)
   pure (x_, y_, z_)
+-----------------------------------------------------------------------------
+instance Thruple Vector3 where
+  thruple (Vector3 j) = pure j
 -----------------------------------------------------------------------------
 

--- a/src/THREE/Vector3.hs
+++ b/src/THREE/Vector3.hs
@@ -45,7 +45,7 @@ vector3ToXYZ (Vector3 v) = do
   z_ <- fromJSValUnchecked =<< v ! ("z" :: JSString)
   pure (x_, y_, z_)
 -----------------------------------------------------------------------------
-instance Thruple Vector3 where
-  thruple (Vector3 j) = pure j
+instance Triplet Vector3 where
+  triplet (Vector3 j) = pure j
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds [EventDispatcher](https://threejs.org/docs/#api/en/core/EventDispatcher) base class.

This makes `EventDispatcher` a superclass of `Object3D`

- [x] Fleshes out `EventDispatcher` module and class
- [x] Puts orphans in `THREE.Internal`
- [x] Introduces `Thruple` class
- [x] Updates `Object3D` to be true to its spec (uses `JSUndefined` and `JSArray`)