### PR TITLE
Add `initialize`

### DIFF
--- a/three.cabal
+++ b/three.cabal
@@ -257,6 +257,7 @@ library
   build-depends:
     base < 5,
     containers,
+    file-embed >= 0.0.16.0,
     jsaddle,
     mtl
   js-sources:


### PR DESCRIPTION
Used to load WASM JS FFI modules, evaluate three.js during jsaddle-warp dev workflow, or no-op if ghcjs